### PR TITLE
Avoid reference to deprecated jax.util.safe_map

### DIFF
--- a/deepseek_r1_jax/deepseek_r1_jax/model.py
+++ b/deepseek_r1_jax/deepseek_r1_jax/model.py
@@ -36,7 +36,6 @@ from jax.sharding import NamedSharding, PartitionSpec as P
 from .decode_ragged_dot import decode_ragged_dot
 
 
-map, builtin_map = jax.util.safe_map, map
 AxisName = str | tuple[str, ...] | None
 Axes = tuple[AxisName, ...]
 

--- a/llama3/llama3_jax/model.py
+++ b/llama3/llama3_jax/model.py
@@ -34,7 +34,6 @@ from etils import epath
 
 from . import ragged_attention
 
-map, builtin_map = jax.util.safe_map, map
 AxisName = str | tuple[str, ...] | None
 Axes = tuple[AxisName, ...]
 

--- a/llama4/llama4_jax/model.py
+++ b/llama4/llama4_jax/model.py
@@ -35,7 +35,6 @@ from etils import epath
 from . import ragged_attention
 from .decode_ragged_dot import decode_ragged_dot
 
-map, builtin_map = jax.util.safe_map, map
 AxisName = str | tuple[str, ...] | None
 Axes = tuple[AxisName, ...]
 

--- a/qwen3/qwen3_jax/model.py
+++ b/qwen3/qwen3_jax/model.py
@@ -35,7 +35,6 @@ from etils import epath
 from . import ragged_attention
 from .decode_ragged_dot import decode_ragged_dot
 
-map, builtin_map = jax.util.safe_map, map
 AxisName = str | tuple[str, ...] | None
 Axes = tuple[AxisName, ...]
 


### PR DESCRIPTION
jax.util was deprecated in JAX v0.6.0, and will be removed in JAX v0.7.0. I opted to simply delete the references, because I could not find any uses of map() in the files.