### PR TITLE
Fix McJax commands and refactor into scripts.

### DIFF
--- a/deepseek_r1_jax/README.md
+++ b/deepseek_r1_jax/README.md
@@ -415,44 +415,15 @@ This section shows how you can do that:
 This guide has specific instructions for setting up a TPU Pod with GCS, but a
 similar setup can be applied to any Linux multi-host platform, including GPU.
 
-### Creating a multi-host TPU VM
+#### Setup McJax
+bash mcjax_setup.sh
 
-```bash
-TPU_ZONE="zone, e.g. us-central1-a"
-PROJECT="your-project"
-IMAGE="v2-alpha-tpuv5-lite"
-ACCELERATOR="v5litepod-64"
-TPU_NAME="my_tpu"
-TPU_NAME="$NAME_PREFIX"-"$ACCELERATOR"
-
-gcloud alpha compute tpus tpu-vm create "$TPU_NAME" --zone="$TPU_ZONE" \
-  --project="$PROJECT" --accelerator-type="$ACCELERATOR" --version="$IMAGE"
+#### Clone the model
 ```
+source mcjax_defs.sh
 
-### Utilities and package installation
-
-```bash
-# Util function to start remote processes on TPU machines.
-TPU_NAME="..."
-TPU_ZONE="..."
-TPU_PROJECT="..."
-
-tpu_exec() {
-    local workers=$(seq $1 $2 | tr '\n' ',')
-    gcloud alpha compute tpus tpu-vm ssh --zone="$TPU_ZONE" --project="$TPU_PROJECT" \
-      "$TPU_NAME" --worker="$workers" --command="$3"
-}
-```
-
-```bash
-# Install required packages and virtualenv.
-INSTALL_COMMAND=$(cat << EOM
-  sudo apt update
-  sudo apt install -y nfs-common nfs-kernel-server nfs-server net-tools tmux python3-ipyparallel
-  curl -LsSf https://astral.sh/uv/install.sh | sh && source ~/.local/bin/env
-  uv python install 3.10 && uv venv --python 3.10
+MODEL_INSTALL_COMMAND=$(cat << EOM
   cd ~/
-  uv pip install -U "jax[tpu]" ipyparallel 
   if [ ! -d jax-llm-examples/deepseek_r1_jax ]; then
     git clone https://github.com/jax-ml/jax-llm-examples.git
   fi
@@ -460,77 +431,28 @@ INSTALL_COMMAND=$(cat << EOM
   uv pip install -e .
 EOM
 )
-
-tpu_exec 0 15 "$INSTALL_COMMAND"
+tpu_exec 0 15 MODEL_INSTALL_COMMAND
 ```
 
-### Setting up code & data on the TPU-VM.
-
-#### 1. [gcsfuse](https://cloud.google.com/storage/docs/cloud-storage-fuse/install#install-source-code)
-
-For datasets and checkpoints.
-
-```bash
-mkdir {local_folder}
-gcsfuse --implicit-dirs {bucket_name_no_gs://} {local_folder}
-```
-#### 2. NFS
-
-For code consistency between hosts in the TPU Pod / Cluster.
-
-```bash
-# on worker 0
-WORKER0_IP="..." # Internal IP address
-mkdir -p ~/nfs; sudo umount ~/nfs
-echo "$HOME/nfs $WORKER0_IP/24(rw,sync,no_subtree_check)" | sudo tee /etc/exports
-sudo exportfs -a
-sudo systemctl enable nfs-server; sudo systemctl restart nfs-server
-sudo chown $USER:$USER -R ~/nfs
-```
-
-```bash
-MOUNT_COMMAND=$(cat << EOM
-  mkdir -p ~/nfs
-  sudo umount ~/nfs
-  # VM_USER should be username in your TPU VM and should be the same across all VM workers.
-  sudo mount -t nfs WORKER0_IP:/home/VM_USER/nfs ~/nfs
-EOM
-)
-tpu_exec 1 15 "$MOUNT_COMMAND"
-```
-
-#### (Optionally) 3. [sshfs](https://github.com/libfuse/sshfs)
-
+#### Setup [sshfs](https://github.com/libfuse/sshfs) (optionally)
 For a quick preview from a local machine.
-
-```bash
-sshfs ~/local_folder TPU_WORKER_0_IP:~/remote_folder
+```
+sshfs ~/$LOCAL_DATA_FOLDER $WORKER0_IP$:~/$LOCAL_DATA_FOLDER
 ```
 
-### Starting the `ipyparallel` cluster
+#### Start the jupyter server
+```
+jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --NotebookApp.token='' --NotebookApp.password=''
+```
 
-Start $N - 1$ workers (ipyparallel calls them `engines`) because we want worker 0 to execute interactively.
-
-```bash
-SERVER_IP="..."
-CONTROLLER_SETUP=$(cat << EOM
-tmux kill-session -t controller; pkill -9 python
-tmux new -d -s controller '\
-  . ~/.venv/bin/activate && ipcontroller --profile-dir=~/nfs --ip=$SERVER_IP'
-EOM
-)
-
-ENGINE_SETUP=$(cat << EOM
-tmux kill-session -t engine; pkill -9 ipengine
-tmux new -d -s engine '. ~/.venv/bin/activate && ipengine --profile-dir=~/nfs'
-EOM
-)
-
-tpu_exec 0 0  "$CONTROLLER_SETUP"  # only worker 0
-tpu_exec 1 15 "$ENGINE_SETUP" # all workers except worker 0
+#### Setup port forward on local machine
+```
+source mcjax_defs.sh
+gcloud alpha compute tpus tpu-vm ssh --zone $TPU_ZONE --project=$TPU_PROJECT $TPU_NAME -L 8888:localhost:8888
 ```
 
 #### Confirm ipyparallel setup works by ssh'ing into worker 0.
+Open http://127.0.0.1:8888/
 > Cell 0:
 ```python
 import ipyparallel as ip

--- a/mcjax_defs.sh
+++ b/mcjax_defs.sh
@@ -1,0 +1,18 @@
+export TPU_ZONE="us-central1-a"
+export TPU_PROJECT={YOUR_PROJECT_ID}
+export IMAGE={YOUR_HARDWARE_TYPE eg v2-alpha-tpuv5-lite}
+export ACCELERATOR="v5litepod-64"
+export TPU_NAME="$USER-v5e-64" # TPU name, change to your own
+export NUM_WORKERS=16
+export VM_USER={$USER_google_com if oslogin is enabled, else $USER}
+export WORKER0_IP={TPU_VM_INTERNAL_IP, e.g. '10.128.0.76'}
+
+export LOCAL_DATA_FOLDER='data'
+export REMOTE_DATA_BUCKET='lancewang-llm-data' # GCS bucket for storing checkpoints, name only, no gs:// prefix
+
+# TPU execution utility function
+tpu_exec() {
+    local workers=$(seq $1 $2 | tr '\n' ',')
+    gcloud alpha compute tpus tpu-vm ssh --zone="$TPU_ZONE" --project="$TPU_PROJECT" \
+      "$TPU_NAME" --worker="$workers" --command="$3" -- -o ProxyCommand='corp-ssh-helper -relay=mtv5.r.ext.google.com %h %p'
+}

--- a/mcjax_setup.sh
+++ b/mcjax_setup.sh
@@ -1,0 +1,77 @@
+# Load the TPU configuration
+source mcjax_defs.sh
+
+# Creat TPU VM
+gcloud alpha compute tpus tpu-vm create "$TPU_NAME" --zone="$TPU_ZONE" \
+  --project="$PROJECT" --accelerator-type="$ACCELERATOR" --version="$IMAGE" \
+  --metadata=enable-oslogin=TRUE
+
+# Install required packages and virtualenv for all the nodes.
+INSTALL_COMMAND=$(cat << EOM
+  rm ./venv -rf
+  sudo pkill -9 apt
+  sudo dpkg --configure -a
+  sudo apt update
+  sudo apt install -y nfs-common nfs-kernel-server nfs-server net-tools tmux python3-ipyparallel
+  curl -LsSf https://astral.sh/uv/install.sh | sh && source ~/.local/bin/env
+  export PATH="\$HOME/.local/bin:\$PATH"
+  uv python install 3.10 && uv venv --python 3.10
+  source .venv/bin/activate
+  uv pip install -U "jax[tpu]" ipyparallel
+EOM
+)
+
+tpu_exec 0 15 "$INSTALL_COMMAND"
+
+# Install jupyter, ipykernel and NFS for node 0
+INSTALL_JUPYTER_COMAND=$(cat << EOM
+  source .venv/bin/activate
+  pip uninstall -y jupyter ipykernel
+  pip install jupyter ipykernel
+  # Create a new kernel for Jupyter to include all the dependencies
+  python -m ipykernel install --user --name uv310 --display-name "Python (uv310)"
+
+  # Setup NFS on node 0
+  mkdir -p ~/nfs; sudo umount ~/nfs
+  echo "\$HOME/nfs $WORKER0_IP/24(rw,sync,no_subtree_check)" | sudo tee /etc/exports
+  sudo exportfs -a
+  sudo systemctl enable nfs-server; sudo systemctl restart nfs-server
+  sudo chown \$USER:\$USER -R ~/nfs
+
+  # Setup gcsfuse for checkpointing
+  mkdir $LOCLA_FOLDER
+  gcsfuse --implicit-dirs $REMOTE_DATA_BUCKET $LOCLA_FOLDER
+EOM
+)
+
+tpu_exec 0 0 "$INSTALL_JUPYTER_COMAND" # only worker 0
+
+MOUNT_COMMAND=$(cat << EOM
+  mkdir -p ~/nfs
+  sudo umount ~/nfs
+  # VM_USER should be username in your TPU VM and should be the same across all VM workers.
+  sudo mount -t nfs $WORKER0_IP:/home/\$VM_USER/nfs ~/nfs
+EOM
+)
+tpu_exec 1 15 "$MOUNT_COMMAND"
+
+CONTROLLER_SETUP=$(cat << EOM
+tmux kill-session -t controller; pkill -9 python;
+sleep 5
+tmux new -d -s controller '\
+  . ~/.venv/bin/activate && ipcontroller --profile-dir=~/nfs --ip=$WORKER0_IP'
+tmux ls
+EOM
+)
+
+ENGINE_SETUP=$(cat << EOM
+tmux kill-session -t engine; pkill -9 ipengine
+sleep 5
+tmux new -d -s engine 'source ~/.venv/bin/activate && ipengine --profile-dir=~/nfs'
+tmux ls
+EOM
+)
+
+tpu_exec 0 0  "$CONTROLLER_SETUP"  # only worker 0
+sleep 10
+tpu_exec 1 15 "$ENGINE_SETUP" # all workers except worker 0

--- a/qwen3/README.md
+++ b/qwen3/README.md
@@ -59,8 +59,8 @@ Responses:
 ```
 Responses:
 [
-  "<think>\nOkay, the user is asking for my name. I need to respond clearly. My name is Qwen, and I'm a large language model developed", 
-  '<think>\nOkay, the user is asking for the weather described in long prose in Old English. First, I need to recall what Old English is like. It', 
+  "<think>\nOkay, the user is asking for my name. I need to respond clearly. My name is Qwen, and I'm a large language model developed",
+  '<think>\nOkay, the user is asking for the weather described in long prose in Old English. First, I need to recall what Old English is like. It',
   '<think>\nOkay, the user is asking, "Do you like ice cream, be extremely precise." Hmm, first, I need to remember that I\'m an'
 ]
 ```
@@ -108,7 +108,7 @@ memory-bandwidth use in inference.
   (e.g. heavy use of custom kernels). In addition, this example only uses
   well-known optimization strategies, and does not aim to introduce any new or
   closed-source techniques that inference providers may have independently developed.
-  
+
 
 
 #### TPU Optimizations
@@ -124,7 +124,7 @@ memory-bandwidth use in inference.
 - Q: Which TPU image to use?
 
   A: For v5e: `v2-alpha-tpuv5-lite`, for v6e: `v2-alpha-tpuv6e`. See [runtimes](https://cloud.google.com/tpu/docs/runtimes).
-  
+
 #### Custom Kernels
 
 TODO
@@ -132,12 +132,12 @@ TODO
 ## Transformer parallelism strategies
 
 This section overviews different sharding strategies and their performance considerations for Transformer architectures in general.
-For a very in-depth guide on this topic, check out [How to Scale Your Model](https://jax-ml.github.io/scaling-book/). 
+For a very in-depth guide on this topic, check out [How to Scale Your Model](https://jax-ml.github.io/scaling-book/).
 The next section goes over Qwen3-specific optimizations.
 
 A typical decoder-only transformer consists of
 
-1. An input embedding 
+1. An input embedding
     - a single weight $V \times D$
 2. Repeated Decoder Layers (Attention + a Feed-forward layer)
     * Attention Layer
@@ -147,11 +147,11 @@ A typical decoder-only transformer consists of
     * Feed-forward Layer - a Multilayer Perceptron (MLP) or a Mixture-of-Experts (MoE)
         - always (i) up-projection -> (ii) nonlinearity -> (iii) down-projection
         - MLP
-            - up-projection: $BSD \times DF \rightarrow BSF$ 
+            - up-projection: $BSD \times DF \rightarrow BSF$
             - down-projection: $BSF \times DF \rightarrow BSD$
         - MoE
             - each token in $BS$ can be routed to a matrix slice $EDF[\text{idx}, :, :]$
-            - up-projection: $BSD \times EDF \rightarrow BSF$ 
+            - up-projection: $BSD \times EDF \rightarrow BSF$
             - down-projection: $BSF \times EDF \rightarrow BSD$
 3. An output projection
     - a single weight $D \times V$
@@ -294,98 +294,46 @@ This section shows how you can do that:
 This guide has specific instructions for setting up a TPU Pod with GCS, but a
 similar setup can be applied to any Linux multi-host platform, including GPU.
 
-### Creating a multi-host TPU VM
-
-```bash
-TPU_ZONE="zone, e.g. us-central1-a"
-PROJECT="your-project"
-IMAGE="v2-alpha-tpuv5-lite"
-ACCELERATOR="v5litepod-64"
-TPU_NAME="my_tpu"
-TPU_NAME="$NAME_PREFIX"-"$ACCELERATOR"
-
-gcloud alpha compute tpus tpu-vm create "$TPU_NAME" --zone="$TPU_ZONE" \
-  --project="$PROJECT" --accelerator-type="$ACCELERATOR" --version="$IMAGE"
+#### Setup McJax
+```
+bash mcjax_setup.sh
 ```
 
-### Setting up code & data
-
-#### 1. [gcsfuse](https://cloud.google.com/storage/docs/cloud-storage-fuse/install#install-source-code)
-
-For datasets and checkpoints.
-
+#### Clone the model
 ```
-gcsfuse --implicit-dirs {bucket_name_no_gs://} {local_folder}
-```
-#### 2. NFS
+source mcjax_defs.sh
 
-For code consistency between hosts in the TPU Pod / Cluster.
-
-```bash
-# on worker 0
-WORKER0_IP="..."
-sudo apt install -y nfs-server nfs-common net-tools tmux
-mkdir -p ~/nfs; sudo umount ~/nfs
-echo "$HOME/nfs $WORKER0_IP/24(rw,sync,no_subtree_check)" | sudo tee /etc/exports
-sudo exportfs -a
-sudo systemctl enable nfs-server; sudo systemctl restart nfs-server
-sudo chown $USER:$USER -R ~/nfs
+MODEL_INSTALL_COMMAND=$(cat << EOM
+  cd ~/
+  if [ ! -d jax-llm-examples/qwen3 ]; then
+    git clone https://github.com/jax-ml/jax-llm-examples.git
+  fi
+  cd jax-llm-examples/qwen3
+  uv pip install -e .
+EOM
+)
+tpu_exec 0 15 MODEL_INSTALL_COMMAND
 ```
 
-```bash
-# on all other workers (!= 0)
-SERVER_IP="..."
-mkdir -p ~/nfs
-sudo umount ~/nfs; sudo mount -t nfs $SERVER_IP:/home/$USER/nfs ~/nfs
-```
-
-#### (Optionally) 3. [sshfs](https://github.com/libfuse/sshfs)
-
+#### Setup [sshfs](https://github.com/libfuse/sshfs) (optionally)
 For a quick preview from a local machine.
-
-```bash
-sshfs ~/local_folder TPU_WORKER_0_IP:~/remote_folder
+```
+sshfs ~/$LOCAL_DATA_FOLDER $WORKER0_IP$:~/$LOCAL_DATA_FOLDER
 ```
 
-### Utilities
-
-```bash
-TPU_NAME="..."
-TPU_ZONE="..."
-TPU_PROJECT="..."
-
-tpu_exec() {
-    local workers=$(seq $1 $2 | tr '\n' ',')
-    gcloud alpha compute tpus tpu-vm ssh --zone="$TPU_ZONE" --project="$TPU_PROJECT" \
-      "$TPU_NAME" --worker="$workers" --command="$2"
-}
-tpu_exec all 'pip install -U "jax[tpu]"'
+#### Start the jupyter server
+```
+jupyter notebook --ip=0.0.0.0 --port=8888 --no-browser --NotebookApp.token='' --NotebookApp.password=''
 ```
 
-### Starting the `ipyparallel` cluster
-
-Start $N - 1$ workers (ipyparallel calls them `engines`) because we want worker 0 to execute interactively.
-
-```bash
-SERVER_IP="..."
-CONTROLLER_SETUP=$(cat << EOM
-tmux kill-session -t controller; pkill -9 python
-tmux new -d -s controller '\
-  . ~/venv/bin/activate && ipcontroller --profile-dir=~/nfs --ip=$SERVER_IP'
-EOM
-)
-
-ENGINE_SETUP=$(cat << EOM
-tmux kill-session -t engine; pkill -9 ipengine
-tmux new -d -s engine '. ~/venv/bin/activate && ipengine --profile-dir=~/nfs'
-EOM
-)
-
-tpu_exec 0 0  "$CONTROLLER_CMD"  # only worker 0
-tpu_exec 1 15 "$ENGINE_CMD" # all workers except worker 0
+#### Setup port forward on local machine
+```
+source mcjax_defs.sh
+gcloud alpha compute tpus tpu-vm ssh --zone $TPU_ZONE --project=$TPU_PROJECT $TPU_NAME -L 8888:localhost:8888
 ```
 
 #### Jupyter Notebook
+Open http://127.0.0.1:8888/
 > Cell 0:
 ```python
 import ipyparallel as ip


### PR DESCRIPTION
The issues in the existing commands:
Didn't enable the virtual env: e.g. after creating venv
Variables are missing $: e.g. sudo mount -t nfs WORKER0_IP:/home/VM_USER/nfs ~/nfs

The current commands are duplicated in all the model folder, hard to manage.

This PR fixes these issues, consolidated to 2 new script files and user should be able to execute it out of the box, with additional minor setup for each model.